### PR TITLE
Cast CONCAT arguments to text for psycopg3

### DIFF
--- a/django/db/models/functions/text.py
+++ b/django/db/models/functions/text.py
@@ -115,6 +115,14 @@ class Concat(Func):
             return ConcatPair(*expressions)
         return ConcatPair(expressions[0], self._paired(expressions[1:]))
 
+    def as_postgresql(self, compiler, connection, **extra_context):
+        sql, params = super().as_sql(compiler, connection, **extra_context)
+        # We have to explicitly cast CONCAT arguments to text in psycopg3,
+        # because in postgres they are defined as 'VARIADIC any'
+        if connection.features.is_psycopg3:
+            sql = sql.replace('%s', '%s::text')
+        return sql, params
+
 
 class Left(Func):
     function = 'LEFT'


### PR DESCRIPTION
Used the same approach as in f9608c7af6df30292d9c5fab82e7a1164be83379.

I guess the only other way is to rewrite whole `as_sql` method for `Concat` class.

`db_functions.text.test_concat` tests are now working!

Test results:
`FAILED (failures=32, errors=93, skipped=399, expected failures=8)`