### PR TITLE
Fix text functions by specifying argument types

### DIFF
--- a/django/contrib/postgres/apps.py
+++ b/django/contrib/postgres/apps.py
@@ -1,6 +1,12 @@
-from psycopg2.extras import (
-    DateRange, DateTimeRange, DateTimeTZRange, NumericRange,
-)
+# TODO: psycopg3
+try:
+    from psycopg2.extras import (
+        DateRange, DateTimeRange, DateTimeTZRange, NumericRange,
+    )
+except ImportError:
+    RANGE_TYPES = ()
+else:
+    RANGE_TYPES = (DateRange, DateTimeRange, DateTimeTZRange, NumericRange)
 
 from django.apps import AppConfig
 from django.db import connections
@@ -14,7 +20,7 @@ from .lookups import SearchLookup, TrigramSimilar, Unaccent
 from .serializers import RangeSerializer
 from .signals import register_type_handlers
 
-RANGE_TYPES = (DateRange, DateTimeRange, DateTimeTZRange, NumericRange)
+# RANGE_TYPES = (DateRange, DateTimeRange, DateTimeTZRange, NumericRange)
 
 
 def uninstall_if_needed(setting, value, enter, **kwargs):

--- a/django/contrib/postgres/fields/ranges.py
+++ b/django/contrib/postgres/fields/ranges.py
@@ -1,7 +1,15 @@
 import datetime
 import json
 
-from psycopg2.extras import DateRange, DateTimeTZRange, NumericRange, Range
+# TODO: psycopg3
+try:
+    from psycopg2.extras import DateRange, DateTimeTZRange, NumericRange, Range
+except ImportError:
+    DateRange = DateTimeTZRange = NumericRange = None
+
+    class Range:
+        pass
+
 
 from django.contrib.postgres import forms, lookups
 from django.db import models

--- a/django/contrib/postgres/forms/ranges.py
+++ b/django/contrib/postgres/forms/ranges.py
@@ -1,4 +1,8 @@
-from psycopg2.extras import DateRange, DateTimeTZRange, NumericRange
+try:
+    from psycopg2.extras import DateRange, DateTimeTZRange, NumericRange
+except ImportError:
+    # TODO
+    DateRange = DateTimeTZRange = NumericRange = None
 
 from django import forms
 from django.core import exceptions

--- a/django/contrib/postgres/search.py
+++ b/django/contrib/postgres/search.py
@@ -1,4 +1,15 @@
-import psycopg2
+try:
+    import psycopg2
+
+    def quote_value(value):
+        return psycopg2.extensions.adapt(value).getquoted().decode()
+
+except ImportError:
+    import psycopg3.sql
+
+    def quote_value(value):
+        return psycopg3.sql.quote(value)
+
 
 from django.db.models import (
     CharField, Expression, Field, FloatField, Func, Lookup, TextField, Value,
@@ -269,8 +280,7 @@ class SearchHeadline(Func):
             # getquoted() returns a quoted bytestring of the adapted value.
             options_params.append(', '.join(
                 '%s=%s' % (
-                    option,
-                    psycopg2.extensions.adapt(value).getquoted().decode(),
+                    option, quote_value(value),
                 ) for option, value in self.options.items()
             ))
             options_sql = ', %s'

--- a/django/contrib/postgres/signals.py
+++ b/django/contrib/postgres/signals.py
@@ -1,8 +1,8 @@
 import functools
 
-import psycopg2
-from psycopg2 import ProgrammingError
-from psycopg2.extras import register_hstore
+# import psycopg2
+# from psycopg2 import ProgrammingError
+# from psycopg2.extras import register_hstore
 
 from django.db import connections
 from django.db.backends.base.base import NO_DB_ALIAS
@@ -37,6 +37,9 @@ def get_citext_oids(connection_alias):
 def register_type_handlers(connection, **kwargs):
     if connection.vendor != 'postgresql' or connection.alias == NO_DB_ALIAS:
         return
+
+    # TODO: psycopg3
+    return
 
     try:
         oids, array_oids = get_hstore_oids(connection.alias)

--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -602,6 +602,9 @@ class BaseDatabaseOperations:
     def combine_duration_expression(self, connector, sub_expressions):
         return self.combine_expression(connector, sub_expressions)
 
+    def json_placeholder_sql(self, value):
+        return '%s'
+
     def binary_placeholder_sql(self, value):
         """
         Some backends require special syntax to insert binary content (MySQL

--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -526,9 +526,6 @@ class BaseDatabaseOperations:
         """
         return value or None
 
-    def adapt_json_value(self, value):
-        return value
-
     def year_lookup_bounds_for_date_field(self, value):
         """
         Return a two-elements list with the lower and upper bound to be used
@@ -604,9 +601,6 @@ class BaseDatabaseOperations:
 
     def combine_duration_expression(self, connector, sub_expressions):
         return self.combine_expression(connector, sub_expressions)
-
-    def json_placeholder_sql(self, value):
-        return '%s'
 
     def binary_placeholder_sql(self, value):
         """

--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -526,6 +526,9 @@ class BaseDatabaseOperations:
         """
         return value or None
 
+    def adapt_json_value(self, value):
+        return value
+
     def year_lookup_bounds_for_date_field(self, value):
         """
         Return a two-elements list with the lower and upper bound to be used

--- a/django/db/backends/postgresql/features.py
+++ b/django/db/backends/postgresql/features.py
@@ -101,3 +101,5 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_covering_gist_indexes = property(operator.attrgetter('is_postgresql_12'))
     supports_non_deterministic_collations = property(operator.attrgetter('is_postgresql_12'))
     supports_alternate_collation_providers = property(operator.attrgetter('is_postgresql_10'))
+    is_psycopg2 = True
+    is_psycopg3 = False

--- a/django/db/backends/postgresql_psycopg3/base.py
+++ b/django/db/backends/postgresql_psycopg3/base.py
@@ -26,8 +26,8 @@ try:
 except ImportError as e:
     raise ImproperlyConfigured("Error loading psycopg3 module: %s" % e)
 
+from psycopg3.oids import builtins
 from psycopg3.types.date import TimestamptzLoader
-from psycopg3.types.oids import builtins
 
 
 def psycopg3_version():

--- a/django/db/backends/postgresql_psycopg3/base.py
+++ b/django/db/backends/postgresql_psycopg3/base.py
@@ -164,7 +164,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
                 )
             )
         conn_params = {
-            'database': settings_dict['NAME'] or 'postgres',
+            'dbname': settings_dict['NAME'] or 'postgres',
             **settings_dict['OPTIONS'],
         }
         conn_params.pop('isolation_level', None)

--- a/django/db/backends/postgresql_psycopg3/base.py
+++ b/django/db/backends/postgresql_psycopg3/base.py
@@ -229,9 +229,11 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     @async_unsafe
     def create_cursor(self, name=None):
         if name:
+            # TODO: server-side cursors
             # In autocommit mode, the cursor will be used outside of a
             # transaction, hence use a holdable cursor.
-            cursor = self.connection.cursor(name, scrollable=False, withhold=self.connection.autocommit)
+            # cursor = self.connection.cursor(name, scrollable=False, withhold=self.connection.autocommit)
+            cursor = self.connection.cursor()
         else:
             cursor = self.connection.cursor()
 

--- a/django/db/backends/postgresql_psycopg3/base.py
+++ b/django/db/backends/postgresql_psycopg3/base.py
@@ -209,7 +209,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     def ensure_timezone(self):
         if self.connection is None:
             return False
-        conn_timezone_name = self.connection.get_parameter_status('TimeZone')
+        conn_timezone_name = self.connection.pgconn.parameter_status(b"TimeZone").decode("ascii")
         timezone_name = self.timezone_name
         if timezone_name and conn_timezone_name != timezone_name:
             with self.connection.cursor() as cursor:
@@ -218,7 +218,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         return False
 
     def init_connection_state(self):
-        self.connection.set_client_encoding('UTF8')
+        self.connection.client_encoding = 'UTF8'
 
         timezone_changed = self.ensure_timezone()
         if timezone_changed:
@@ -326,7 +326,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     @cached_property
     def pg_version(self):
         with self.temporary_connection():
-            return self.connection.server_version
+            return self.connection.pgconn.server_version
 
     def make_debug_cursor(self, cursor):
         return CursorDebugWrapper(cursor, self)

--- a/django/db/backends/postgresql_psycopg3/base.py
+++ b/django/db/backends/postgresql_psycopg3/base.py
@@ -28,6 +28,7 @@ except ImportError as e:
 
 from psycopg3.oids import builtins
 from psycopg3.types.date import TimestamptzLoader
+from psycopg3.types.text import TextLoader
 
 
 def psycopg3_version():
@@ -201,11 +202,6 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         #     if self.isolation_level != connection.isolation_level:
         #         connection.set_session(isolation_level=self.isolation_level)
 
-        # Register dummy loads() to avoid a round trip from psycopg2's decode
-        # to json.dumps() to json.loads(), when using a custom decoder in
-        # JSONField.
-        # TODO: equivalent for psycopg3 once merged to master
-        # psycopg2.extras.register_default_jsonb(conn_or_curs=connection, loads=lambda x: x)
         return connection
 
     def ensure_timezone(self):
@@ -233,6 +229,11 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         else:
             ConfigTzLoader.timezone = self.timezone
             ConfigTzLoader.register(builtins["timestamptz"].oid, self.connection)
+
+        # Register dummy loads() to avoid a round trip from psycopg3's decode
+        # to json.dumps() to json.loads(), when using a custom decoder in
+        # JSONField.
+        TextLoader.register(builtins["jsonb"].oid, self.connection)
 
     @async_unsafe
     def create_cursor(self, name=None):

--- a/django/db/backends/postgresql_psycopg3/base.py
+++ b/django/db/backends/postgresql_psycopg3/base.py
@@ -28,7 +28,7 @@ except ImportError as e:
 
 from psycopg3.oids import builtins
 from psycopg3.types.date import TimestamptzLoader
-from psycopg3.types.text import TextLoader, StringDumper
+from psycopg3.types.text import TextLoader
 
 
 def psycopg3_version():
@@ -43,7 +43,7 @@ from .client import DatabaseClient                          # NOQA isort:skip
 from .creation import DatabaseCreation                      # NOQA isort:skip
 from .features import DatabaseFeatures                      # NOQA isort:skip
 from .introspection import DatabaseIntrospection            # NOQA isort:skip
-from .operations import DatabaseOperations, JsonWrapper     # NOQA isort:skip
+from .operations import DatabaseOperations                  # NOQA isort:skip
 from .schema import DatabaseSchemaEditor                    # NOQA isort:skip
 
 # TODO: psycopg3 Should be automatic
@@ -230,16 +230,10 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             ConfigTzLoader.timezone = self.timezone
             ConfigTzLoader.register(builtins["timestamptz"].oid, self.connection)
 
-        # Register dummy loads() to avoid a round trip from psycopg3's decode
+        # Register a no-op dumper to avoid a round trip from psycopg3's decode
         # to json.dumps() to json.loads(), when using a custom decoder in
         # JSONField.
         TextLoader.register(builtins["jsonb"].oid, self.connection)
-
-        # Register a no-op dumper t  avoid a round trip from psycopg3's decode
-        # to json.dumps() to json.loads(), when using a custom decoder in
-        # JSONField.
-        TextLoader.register(JSONB_OID, self.connection)
-        JsonDumper.register(JsonWrapper, self.connection)
 
     @async_unsafe
     def create_cursor(self, name=None):
@@ -362,16 +356,6 @@ class ConfigTzLoader(TimestamptzLoader):
     def load(self, data):
         res = super().load(data)
         return res.replace(tzinfo=self.timezone)
-
-
-class JsonDumper(StringDumper):
-    """
-    Dump a json object already converted to string to the database.
-    """
-    oid = JSONB_OID
-
-    def dump(self, obj):
-        return super().dump(obj.wrapped)
 
 
 class CursorDebugWrapper(BaseCursorDebugWrapper):

--- a/django/db/backends/postgresql_psycopg3/base.py
+++ b/django/db/backends/postgresql_psycopg3/base.py
@@ -224,12 +224,6 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             if not self.get_autocommit():
                 self.connection.commit()
 
-        if not settings.USE_TZ:
-            ChopTzLoader.register(builtins["timestamptz"].oid, self.connection)
-        else:
-            ConfigTzLoader.timezone = self.timezone
-            ConfigTzLoader.register(builtins["timestamptz"].oid, self.connection)
-
         # Register a no-op dumper to avoid a round trip from psycopg3's decode
         # to json.dumps() to json.loads(), when using a custom decoder in
         # JSONField.
@@ -245,6 +239,12 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             cursor = self.connection.cursor()
         else:
             cursor = self.connection.cursor()
+
+        if settings.USE_TZ:
+            ConfigTzLoader.timezone = self.timezone
+            ConfigTzLoader.register(builtins["timestamptz"].oid, self.connection)
+        else:
+            ChopTzLoader.register(builtins["timestamptz"].oid, self.connection)
 
         return cursor
 

--- a/django/db/backends/postgresql_psycopg3/base.py
+++ b/django/db/backends/postgresql_psycopg3/base.py
@@ -229,6 +229,10 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         # JSONField.
         TextLoader.register(builtins["jsonb"].oid, self.connection)
 
+        # Don't convert automatically from Postgres network types to Python ipaddress
+        TextLoader.register(builtins["inet"].oid, self.connection)
+        TextLoader.register(builtins["cidr"].oid, self.connection)
+
     @async_unsafe
     def create_cursor(self, name=None):
         if name:

--- a/django/db/backends/postgresql_psycopg3/base.py
+++ b/django/db/backends/postgresql_psycopg3/base.py
@@ -1,0 +1,340 @@
+"""
+PostgreSQL database backend for Django.
+
+Requires psycopg 2: https://www.psycopg.org/
+"""
+
+import asyncio
+import threading
+import warnings
+from contextlib import contextmanager
+
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+from django.db import DatabaseError as WrappedDatabaseError, connections
+from django.db.backends.base.base import BaseDatabaseWrapper
+from django.db.backends.utils import (
+    CursorDebugWrapper as BaseCursorDebugWrapper,
+)
+from django.utils.asyncio import async_unsafe
+from django.utils.functional import cached_property
+from django.utils.safestring import SafeString
+from django.utils.version import get_version_tuple
+
+try:
+    import psycopg2 as Database
+    import psycopg2.extensions
+    import psycopg2.extras
+except ImportError as e:
+    raise ImproperlyConfigured("Error loading psycopg2 module: %s" % e)
+
+
+def psycopg2_version():
+    version = psycopg2.__version__.split(' ', 1)[0]
+    return get_version_tuple(version)
+
+
+PSYCOPG2_VERSION = psycopg2_version()
+
+if PSYCOPG2_VERSION < (2, 5, 4):
+    raise ImproperlyConfigured("psycopg2_version 2.5.4 or newer is required; you have %s" % psycopg2.__version__)
+
+
+# Some of these import psycopg2, so import them after checking if it's installed.
+from .client import DatabaseClient                          # NOQA isort:skip
+from .creation import DatabaseCreation                      # NOQA isort:skip
+from .features import DatabaseFeatures                      # NOQA isort:skip
+from .introspection import DatabaseIntrospection            # NOQA isort:skip
+from .operations import DatabaseOperations                  # NOQA isort:skip
+from .schema import DatabaseSchemaEditor                    # NOQA isort:skip
+
+psycopg2.extensions.register_adapter(SafeString, psycopg2.extensions.QuotedString)
+psycopg2.extras.register_uuid()
+
+# Register support for inet[] manually so we don't have to handle the Inet()
+# object on load all the time.
+INETARRAY_OID = 1041
+INETARRAY = psycopg2.extensions.new_array_type(
+    (INETARRAY_OID,),
+    'INETARRAY',
+    psycopg2.extensions.UNICODE,
+)
+psycopg2.extensions.register_type(INETARRAY)
+
+
+class DatabaseWrapper(BaseDatabaseWrapper):
+    vendor = 'postgresql'
+    display_name = 'PostgreSQL'
+    # This dictionary maps Field objects to their associated PostgreSQL column
+    # types, as strings. Column-type strings can contain format strings; they'll
+    # be interpolated against the values of Field.__dict__ before being output.
+    # If a column type is set to None, it won't be included in the output.
+    data_types = {
+        'AutoField': 'serial',
+        'BigAutoField': 'bigserial',
+        'BinaryField': 'bytea',
+        'BooleanField': 'boolean',
+        'CharField': 'varchar(%(max_length)s)',
+        'DateField': 'date',
+        'DateTimeField': 'timestamp with time zone',
+        'DecimalField': 'numeric(%(max_digits)s, %(decimal_places)s)',
+        'DurationField': 'interval',
+        'FileField': 'varchar(%(max_length)s)',
+        'FilePathField': 'varchar(%(max_length)s)',
+        'FloatField': 'double precision',
+        'IntegerField': 'integer',
+        'BigIntegerField': 'bigint',
+        'IPAddressField': 'inet',
+        'GenericIPAddressField': 'inet',
+        'JSONField': 'jsonb',
+        'NullBooleanField': 'boolean',
+        'OneToOneField': 'integer',
+        'PositiveBigIntegerField': 'bigint',
+        'PositiveIntegerField': 'integer',
+        'PositiveSmallIntegerField': 'smallint',
+        'SlugField': 'varchar(%(max_length)s)',
+        'SmallAutoField': 'smallserial',
+        'SmallIntegerField': 'smallint',
+        'TextField': 'text',
+        'TimeField': 'time',
+        'UUIDField': 'uuid',
+    }
+    data_type_check_constraints = {
+        'PositiveBigIntegerField': '"%(column)s" >= 0',
+        'PositiveIntegerField': '"%(column)s" >= 0',
+        'PositiveSmallIntegerField': '"%(column)s" >= 0',
+    }
+    operators = {
+        'exact': '= %s',
+        'iexact': '= UPPER(%s)',
+        'contains': 'LIKE %s',
+        'icontains': 'LIKE UPPER(%s)',
+        'regex': '~ %s',
+        'iregex': '~* %s',
+        'gt': '> %s',
+        'gte': '>= %s',
+        'lt': '< %s',
+        'lte': '<= %s',
+        'startswith': 'LIKE %s',
+        'endswith': 'LIKE %s',
+        'istartswith': 'LIKE UPPER(%s)',
+        'iendswith': 'LIKE UPPER(%s)',
+    }
+
+    # The patterns below are used to generate SQL pattern lookup clauses when
+    # the right-hand side of the lookup isn't a raw string (it might be an expression
+    # or the result of a bilateral transformation).
+    # In those cases, special characters for LIKE operators (e.g. \, *, _) should be
+    # escaped on database side.
+    #
+    # Note: we use str.format() here for readability as '%' is used as a wildcard for
+    # the LIKE operator.
+    pattern_esc = r"REPLACE(REPLACE(REPLACE({}, E'\\', E'\\\\'), E'%%', E'\\%%'), E'_', E'\\_')"
+    pattern_ops = {
+        'contains': "LIKE '%%' || {} || '%%'",
+        'icontains': "LIKE '%%' || UPPER({}) || '%%'",
+        'startswith': "LIKE {} || '%%'",
+        'istartswith': "LIKE UPPER({}) || '%%'",
+        'endswith': "LIKE '%%' || {}",
+        'iendswith': "LIKE '%%' || UPPER({})",
+    }
+
+    Database = Database
+    SchemaEditorClass = DatabaseSchemaEditor
+    # Classes instantiated in __init__().
+    client_class = DatabaseClient
+    creation_class = DatabaseCreation
+    features_class = DatabaseFeatures
+    introspection_class = DatabaseIntrospection
+    ops_class = DatabaseOperations
+    # PostgreSQL backend-specific attributes.
+    _named_cursor_idx = 0
+
+    def get_connection_params(self):
+        settings_dict = self.settings_dict
+        # None may be used to connect to the default 'postgres' db
+        if settings_dict['NAME'] == '':
+            raise ImproperlyConfigured(
+                "settings.DATABASES is improperly configured. "
+                "Please supply the NAME value.")
+        if len(settings_dict['NAME'] or '') > self.ops.max_name_length():
+            raise ImproperlyConfigured(
+                "The database name '%s' (%d characters) is longer than "
+                "PostgreSQL's limit of %d characters. Supply a shorter NAME "
+                "in settings.DATABASES." % (
+                    settings_dict['NAME'],
+                    len(settings_dict['NAME']),
+                    self.ops.max_name_length(),
+                )
+            )
+        conn_params = {
+            'database': settings_dict['NAME'] or 'postgres',
+            **settings_dict['OPTIONS'],
+        }
+        conn_params.pop('isolation_level', None)
+        if settings_dict['USER']:
+            conn_params['user'] = settings_dict['USER']
+        if settings_dict['PASSWORD']:
+            conn_params['password'] = settings_dict['PASSWORD']
+        if settings_dict['HOST']:
+            conn_params['host'] = settings_dict['HOST']
+        if settings_dict['PORT']:
+            conn_params['port'] = settings_dict['PORT']
+        return conn_params
+
+    @async_unsafe
+    def get_new_connection(self, conn_params):
+        connection = Database.connect(**conn_params)
+
+        # self.isolation_level must be set:
+        # - after connecting to the database in order to obtain the database's
+        #   default when no value is explicitly specified in options.
+        # - before calling _set_autocommit() because if autocommit is on, that
+        #   will set connection.isolation_level to ISOLATION_LEVEL_AUTOCOMMIT.
+        options = self.settings_dict['OPTIONS']
+        try:
+            self.isolation_level = options['isolation_level']
+        except KeyError:
+            self.isolation_level = connection.isolation_level
+        else:
+            # Set the isolation level to the value from OPTIONS.
+            if self.isolation_level != connection.isolation_level:
+                connection.set_session(isolation_level=self.isolation_level)
+        # Register dummy loads() to avoid a round trip from psycopg2's decode
+        # to json.dumps() to json.loads(), when using a custom decoder in
+        # JSONField.
+        psycopg2.extras.register_default_jsonb(conn_or_curs=connection, loads=lambda x: x)
+        return connection
+
+    def ensure_timezone(self):
+        if self.connection is None:
+            return False
+        conn_timezone_name = self.connection.get_parameter_status('TimeZone')
+        timezone_name = self.timezone_name
+        if timezone_name and conn_timezone_name != timezone_name:
+            with self.connection.cursor() as cursor:
+                cursor.execute(self.ops.set_time_zone_sql(), [timezone_name])
+            return True
+        return False
+
+    def init_connection_state(self):
+        self.connection.set_client_encoding('UTF8')
+
+        timezone_changed = self.ensure_timezone()
+        if timezone_changed:
+            # Commit after setting the time zone (see #17062)
+            if not self.get_autocommit():
+                self.connection.commit()
+
+    @async_unsafe
+    def create_cursor(self, name=None):
+        if name:
+            # In autocommit mode, the cursor will be used outside of a
+            # transaction, hence use a holdable cursor.
+            cursor = self.connection.cursor(name, scrollable=False, withhold=self.connection.autocommit)
+        else:
+            cursor = self.connection.cursor()
+        cursor.tzinfo_factory = self.tzinfo_factory if settings.USE_TZ else None
+        return cursor
+
+    def tzinfo_factory(self, offset):
+        return self.timezone
+
+    @async_unsafe
+    def chunked_cursor(self):
+        self._named_cursor_idx += 1
+        # Get the current async task
+        # Note that right now this is behind @async_unsafe, so this is
+        # unreachable, but in future we'll start loosening this restriction.
+        # For now, it's here so that every use of "threading" is
+        # also async-compatible.
+        try:
+            if hasattr(asyncio, 'current_task'):
+                # Python 3.7 and up
+                current_task = asyncio.current_task()
+            else:
+                # Python 3.6
+                current_task = asyncio.Task.current_task()
+        except RuntimeError:
+            current_task = None
+        # Current task can be none even if the current_task call didn't error
+        if current_task:
+            task_ident = str(id(current_task))
+        else:
+            task_ident = 'sync'
+        # Use that and the thread ident to get a unique name
+        return self._cursor(
+            name='_django_curs_%d_%s_%d' % (
+                # Avoid reusing name in other threads / tasks
+                threading.current_thread().ident,
+                task_ident,
+                self._named_cursor_idx,
+            )
+        )
+
+    def _set_autocommit(self, autocommit):
+        with self.wrap_database_errors:
+            self.connection.autocommit = autocommit
+
+    def check_constraints(self, table_names=None):
+        """
+        Check constraints by setting them to immediate. Return them to deferred
+        afterward.
+        """
+        with self.cursor() as cursor:
+            cursor.execute('SET CONSTRAINTS ALL IMMEDIATE')
+            cursor.execute('SET CONSTRAINTS ALL DEFERRED')
+
+    def is_usable(self):
+        try:
+            # Use a psycopg cursor directly, bypassing Django's utilities.
+            with self.connection.cursor() as cursor:
+                cursor.execute('SELECT 1')
+        except Database.Error:
+            return False
+        else:
+            return True
+
+    @contextmanager
+    def _nodb_cursor(self):
+        try:
+            with super()._nodb_cursor() as cursor:
+                yield cursor
+        except (Database.DatabaseError, WrappedDatabaseError):
+            warnings.warn(
+                "Normally Django will use a connection to the 'postgres' database "
+                "to avoid running initialization queries against the production "
+                "database when it's not needed (for example, when running tests). "
+                "Django was unable to create a connection to the 'postgres' database "
+                "and will use the first PostgreSQL database instead.",
+                RuntimeWarning
+            )
+            for connection in connections.all():
+                if connection.vendor == 'postgresql' and connection.settings_dict['NAME'] != 'postgres':
+                    conn = self.__class__(
+                        {**self.settings_dict, 'NAME': connection.settings_dict['NAME']},
+                        alias=self.alias,
+                    )
+                    try:
+                        with conn.cursor() as cursor:
+                            yield cursor
+                    finally:
+                        conn.close()
+
+    @cached_property
+    def pg_version(self):
+        with self.temporary_connection():
+            return self.connection.server_version
+
+    def make_debug_cursor(self, cursor):
+        return CursorDebugWrapper(cursor, self)
+
+
+class CursorDebugWrapper(BaseCursorDebugWrapper):
+    def copy_expert(self, sql, file, *args):
+        with self.debug_sql(sql):
+            return self.cursor.copy_expert(sql, file, *args)
+
+    def copy_to(self, file, table, *args, **kwargs):
+        with self.debug_sql(sql='COPY %s TO STDOUT' % table):
+            return self.cursor.copy_to(file, table, *args, **kwargs)

--- a/django/db/backends/postgresql_psycopg3/client.py
+++ b/django/db/backends/postgresql_psycopg3/client.py
@@ -1,0 +1,55 @@
+import os
+import signal
+import subprocess
+
+from django.db.backends.base.client import BaseDatabaseClient
+
+
+class DatabaseClient(BaseDatabaseClient):
+    executable_name = 'psql'
+
+    @classmethod
+    def runshell_db(cls, conn_params, parameters):
+        args = [cls.executable_name]
+
+        host = conn_params.get('host', '')
+        port = conn_params.get('port', '')
+        dbname = conn_params.get('database', '')
+        user = conn_params.get('user', '')
+        passwd = conn_params.get('password', '')
+        sslmode = conn_params.get('sslmode', '')
+        sslrootcert = conn_params.get('sslrootcert', '')
+        sslcert = conn_params.get('sslcert', '')
+        sslkey = conn_params.get('sslkey', '')
+
+        if user:
+            args += ['-U', user]
+        if host:
+            args += ['-h', host]
+        if port:
+            args += ['-p', str(port)]
+        args += [dbname]
+        args.extend(parameters)
+
+        sigint_handler = signal.getsignal(signal.SIGINT)
+        subprocess_env = os.environ.copy()
+        if passwd:
+            subprocess_env['PGPASSWORD'] = str(passwd)
+        if sslmode:
+            subprocess_env['PGSSLMODE'] = str(sslmode)
+        if sslrootcert:
+            subprocess_env['PGSSLROOTCERT'] = str(sslrootcert)
+        if sslcert:
+            subprocess_env['PGSSLCERT'] = str(sslcert)
+        if sslkey:
+            subprocess_env['PGSSLKEY'] = str(sslkey)
+        try:
+            # Allow SIGINT to pass to psql to abort queries.
+            signal.signal(signal.SIGINT, signal.SIG_IGN)
+            subprocess.run(args, check=True, env=subprocess_env)
+        finally:
+            # Restore the original SIGINT handler.
+            signal.signal(signal.SIGINT, sigint_handler)
+
+    def runshell(self, parameters):
+        self.runshell_db(self.connection.get_connection_params(), parameters)

--- a/django/db/backends/postgresql_psycopg3/creation.py
+++ b/django/db/backends/postgresql_psycopg3/creation.py
@@ -1,0 +1,77 @@
+import sys
+
+from psycopg2 import errorcodes
+
+from django.db.backends.base.creation import BaseDatabaseCreation
+from django.db.backends.utils import strip_quotes
+
+
+class DatabaseCreation(BaseDatabaseCreation):
+
+    def _quote_name(self, name):
+        return self.connection.ops.quote_name(name)
+
+    def _get_database_create_suffix(self, encoding=None, template=None):
+        suffix = ""
+        if encoding:
+            suffix += " ENCODING '{}'".format(encoding)
+        if template:
+            suffix += " TEMPLATE {}".format(self._quote_name(template))
+        return suffix and "WITH" + suffix
+
+    def sql_table_creation_suffix(self):
+        test_settings = self.connection.settings_dict['TEST']
+        assert test_settings['COLLATION'] is None, (
+            "PostgreSQL does not support collation setting at database creation time."
+        )
+        return self._get_database_create_suffix(
+            encoding=test_settings['CHARSET'],
+            template=test_settings.get('TEMPLATE'),
+        )
+
+    def _database_exists(self, cursor, database_name):
+        cursor.execute('SELECT 1 FROM pg_catalog.pg_database WHERE datname = %s', [strip_quotes(database_name)])
+        return cursor.fetchone() is not None
+
+    def _execute_create_test_db(self, cursor, parameters, keepdb=False):
+        try:
+            if keepdb and self._database_exists(cursor, parameters['dbname']):
+                # If the database should be kept and it already exists, don't
+                # try to create a new one.
+                return
+            super()._execute_create_test_db(cursor, parameters, keepdb)
+        except Exception as e:
+            if getattr(e.__cause__, 'pgcode', '') != errorcodes.DUPLICATE_DATABASE:
+                # All errors except "database already exists" cancel tests.
+                self.log('Got an error creating the test database: %s' % e)
+                sys.exit(2)
+            elif not keepdb:
+                # If the database should be kept, ignore "database already
+                # exists".
+                raise
+
+    def _clone_test_db(self, suffix, verbosity, keepdb=False):
+        # CREATE DATABASE ... WITH TEMPLATE ... requires closing connections
+        # to the template database.
+        self.connection.close()
+
+        source_database_name = self.connection.settings_dict['NAME']
+        target_database_name = self.get_test_db_clone_settings(suffix)['NAME']
+        test_db_params = {
+            'dbname': self._quote_name(target_database_name),
+            'suffix': self._get_database_create_suffix(template=source_database_name),
+        }
+        with self._nodb_cursor() as cursor:
+            try:
+                self._execute_create_test_db(cursor, test_db_params, keepdb)
+            except Exception:
+                try:
+                    if verbosity >= 1:
+                        self.log('Destroying old test database for alias %s...' % (
+                            self._get_database_display_str(verbosity, target_database_name),
+                        ))
+                    cursor.execute('DROP DATABASE %(dbname)s' % test_db_params)
+                    self._execute_create_test_db(cursor, test_db_params, keepdb)
+                except Exception as e:
+                    self.log('Got an error cloning the test database: %s' % e)
+                    sys.exit(2)

--- a/django/db/backends/postgresql_psycopg3/creation.py
+++ b/django/db/backends/postgresql_psycopg3/creation.py
@@ -1,6 +1,6 @@
 import sys
 
-from psycopg2 import errorcodes
+from psycopg3 import errors
 
 from django.db.backends.base.creation import BaseDatabaseCreation
 from django.db.backends.utils import strip_quotes
@@ -41,7 +41,7 @@ class DatabaseCreation(BaseDatabaseCreation):
                 return
             super()._execute_create_test_db(cursor, parameters, keepdb)
         except Exception as e:
-            if getattr(e.__cause__, 'pgcode', '') != errorcodes.DUPLICATE_DATABASE:
+            if not isinstance(e.__cause__, errors.DuplicateDatabase):
                 # All errors except "database already exists" cancel tests.
                 self.log('Got an error creating the test database: %s' % e)
                 sys.exit(2)

--- a/django/db/backends/postgresql_psycopg3/features.py
+++ b/django/db/backends/postgresql_psycopg3/features.py
@@ -103,3 +103,5 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_covering_gist_indexes = property(operator.attrgetter('is_postgresql_12'))
     supports_non_deterministic_collations = property(operator.attrgetter('is_postgresql_12'))
     supports_alternate_collation_providers = property(operator.attrgetter('is_postgresql_10'))
+    is_psycopg2 = False
+    is_psycopg3 = True

--- a/django/db/backends/postgresql_psycopg3/features.py
+++ b/django/db/backends/postgresql_psycopg3/features.py
@@ -1,0 +1,103 @@
+import operator
+
+from django.db import InterfaceError
+from django.db.backends.base.features import BaseDatabaseFeatures
+from django.utils.functional import cached_property
+
+
+class DatabaseFeatures(BaseDatabaseFeatures):
+    allows_group_by_selected_pks = True
+    can_return_columns_from_insert = True
+    can_return_rows_from_bulk_insert = True
+    has_real_datatype = True
+    has_native_uuid_field = True
+    has_native_duration_field = True
+    has_native_json_field = True
+    can_defer_constraint_checks = True
+    has_select_for_update = True
+    has_select_for_update_nowait = True
+    has_select_for_update_of = True
+    has_select_for_update_skip_locked = True
+    has_select_for_no_key_update = True
+    can_release_savepoints = True
+    supports_tablespaces = True
+    supports_transactions = True
+    can_introspect_materialized_views = True
+    can_distinct_on_fields = True
+    can_rollback_ddl = True
+    supports_combined_alters = True
+    nulls_order_largest = True
+    closed_cursor_error_class = InterfaceError
+    has_case_insensitive_like = False
+    greatest_least_ignores_nulls = True
+    can_clone_databases = True
+    supports_temporal_subtraction = True
+    supports_slicing_ordering_in_compound = True
+    create_test_procedure_without_params_sql = """
+        CREATE FUNCTION test_procedure () RETURNS void AS $$
+        DECLARE
+            V_I INTEGER;
+        BEGIN
+            V_I := 1;
+        END;
+    $$ LANGUAGE plpgsql;"""
+    create_test_procedure_with_int_param_sql = """
+        CREATE FUNCTION test_procedure (P_I INTEGER) RETURNS void AS $$
+        DECLARE
+            V_I INTEGER;
+        BEGIN
+            V_I := P_I;
+        END;
+    $$ LANGUAGE plpgsql;"""
+    requires_casted_case_in_updates = True
+    supports_over_clause = True
+    only_supports_unbounded_with_preceding_and_following = True
+    supports_aggregate_filter_clause = True
+    supported_explain_formats = {'JSON', 'TEXT', 'XML', 'YAML'}
+    validates_explain_options = False  # A query will error on invalid options.
+    supports_deferrable_unique_constraints = True
+    has_json_operators = True
+    json_key_contains_list_matching_requires_list = True
+
+    @cached_property
+    def test_collations(self):
+        # PostgreSQL < 10 doesn't support ICU collations.
+        if self.is_postgresql_10:
+            return {
+                'non_default': 'sv-x-icu',
+                'swedish_ci': 'sv-x-icu',
+            }
+        return {}
+
+    @cached_property
+    def introspected_field_types(self):
+        return {
+            **super().introspected_field_types,
+            'PositiveBigIntegerField': 'BigIntegerField',
+            'PositiveIntegerField': 'IntegerField',
+            'PositiveSmallIntegerField': 'SmallIntegerField',
+        }
+
+    @cached_property
+    def is_postgresql_10(self):
+        return self.connection.pg_version >= 100000
+
+    @cached_property
+    def is_postgresql_11(self):
+        return self.connection.pg_version >= 110000
+
+    @cached_property
+    def is_postgresql_12(self):
+        return self.connection.pg_version >= 120000
+
+    @cached_property
+    def is_postgresql_13(self):
+        return self.connection.pg_version >= 130000
+
+    has_brin_autosummarize = property(operator.attrgetter('is_postgresql_10'))
+    has_websearch_to_tsquery = property(operator.attrgetter('is_postgresql_11'))
+    supports_table_partitions = property(operator.attrgetter('is_postgresql_10'))
+    supports_covering_indexes = property(operator.attrgetter('is_postgresql_11'))
+    supports_covering_gist_indexes = property(operator.attrgetter('is_postgresql_12'))
+    supports_non_deterministic_collations = property(operator.attrgetter('is_postgresql_12'))
+    supports_alternate_collation_providers = property(operator.attrgetter('is_postgresql_10'))

--- a/django/db/backends/postgresql_psycopg3/features.py
+++ b/django/db/backends/postgresql_psycopg3/features.py
@@ -53,6 +53,8 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_over_clause = True
     only_supports_unbounded_with_preceding_and_following = True
     supports_aggregate_filter_clause = True
+    # TODO: psyocpg3 it would, but maybe tests must be fixed
+    # supports_callproc_kwargs = True
     supported_explain_formats = {'JSON', 'TEXT', 'XML', 'YAML'}
     validates_explain_options = False  # A query will error on invalid options.
     supports_deferrable_unique_constraints = True

--- a/django/db/backends/postgresql_psycopg3/introspection.py
+++ b/django/db/backends/postgresql_psycopg3/introspection.py
@@ -1,0 +1,234 @@
+from django.db.backends.base.introspection import (
+    BaseDatabaseIntrospection, FieldInfo, TableInfo,
+)
+from django.db.models import Index
+
+
+class DatabaseIntrospection(BaseDatabaseIntrospection):
+    # Maps type codes to Django Field types.
+    data_types_reverse = {
+        16: 'BooleanField',
+        17: 'BinaryField',
+        20: 'BigIntegerField',
+        21: 'SmallIntegerField',
+        23: 'IntegerField',
+        25: 'TextField',
+        700: 'FloatField',
+        701: 'FloatField',
+        869: 'GenericIPAddressField',
+        1042: 'CharField',  # blank-padded
+        1043: 'CharField',
+        1082: 'DateField',
+        1083: 'TimeField',
+        1114: 'DateTimeField',
+        1184: 'DateTimeField',
+        1186: 'DurationField',
+        1266: 'TimeField',
+        1700: 'DecimalField',
+        2950: 'UUIDField',
+        3802: 'JSONField',
+    }
+    # A hook for subclasses.
+    index_default_access_method = 'btree'
+
+    ignored_tables = []
+
+    def get_field_type(self, data_type, description):
+        field_type = super().get_field_type(data_type, description)
+        if description.default and 'nextval' in description.default:
+            if field_type == 'IntegerField':
+                return 'AutoField'
+            elif field_type == 'BigIntegerField':
+                return 'BigAutoField'
+            elif field_type == 'SmallIntegerField':
+                return 'SmallAutoField'
+        return field_type
+
+    def get_table_list(self, cursor):
+        """Return a list of table and view names in the current database."""
+        cursor.execute("""
+            SELECT c.relname,
+            CASE WHEN {} THEN 'p' WHEN c.relkind IN ('m', 'v') THEN 'v' ELSE 't' END
+            FROM pg_catalog.pg_class c
+            LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+            WHERE c.relkind IN ('f', 'm', 'p', 'r', 'v')
+                AND n.nspname NOT IN ('pg_catalog', 'pg_toast')
+                AND pg_catalog.pg_table_is_visible(c.oid)
+        """.format('c.relispartition' if self.connection.features.supports_table_partitions else 'FALSE'))
+        return [TableInfo(*row) for row in cursor.fetchall() if row[0] not in self.ignored_tables]
+
+    def get_table_description(self, cursor, table_name):
+        """
+        Return a description of the table with the DB-API cursor.description
+        interface.
+        """
+        # Query the pg_catalog tables as cursor.description does not reliably
+        # return the nullable property and information_schema.columns does not
+        # contain details of materialized views.
+        cursor.execute("""
+            SELECT
+                a.attname AS column_name,
+                NOT (a.attnotnull OR (t.typtype = 'd' AND t.typnotnull)) AS is_nullable,
+                pg_get_expr(ad.adbin, ad.adrelid) AS column_default,
+                CASE WHEN collname = 'default' THEN NULL ELSE collname END AS collation
+            FROM pg_attribute a
+            LEFT JOIN pg_attrdef ad ON a.attrelid = ad.adrelid AND a.attnum = ad.adnum
+            LEFT JOIN pg_collation co ON a.attcollation = co.oid
+            JOIN pg_type t ON a.atttypid = t.oid
+            JOIN pg_class c ON a.attrelid = c.oid
+            JOIN pg_namespace n ON c.relnamespace = n.oid
+            WHERE c.relkind IN ('f', 'm', 'p', 'r', 'v')
+                AND c.relname = %s
+                AND n.nspname NOT IN ('pg_catalog', 'pg_toast')
+                AND pg_catalog.pg_table_is_visible(c.oid)
+        """, [table_name])
+        field_map = {line[0]: line[1:] for line in cursor.fetchall()}
+        cursor.execute("SELECT * FROM %s LIMIT 1" % self.connection.ops.quote_name(table_name))
+        return [
+            FieldInfo(
+                line.name,
+                line.type_code,
+                line.display_size,
+                line.internal_size,
+                line.precision,
+                line.scale,
+                *field_map[line.name],
+            )
+            for line in cursor.description
+        ]
+
+    def get_sequences(self, cursor, table_name, table_fields=()):
+        cursor.execute("""
+            SELECT s.relname as sequence_name, col.attname
+            FROM pg_class s
+                JOIN pg_namespace sn ON sn.oid = s.relnamespace
+                JOIN pg_depend d ON d.refobjid = s.oid AND d.refclassid = 'pg_class'::regclass
+                JOIN pg_attrdef ad ON ad.oid = d.objid AND d.classid = 'pg_attrdef'::regclass
+                JOIN pg_attribute col ON col.attrelid = ad.adrelid AND col.attnum = ad.adnum
+                JOIN pg_class tbl ON tbl.oid = ad.adrelid
+            WHERE s.relkind = 'S'
+              AND d.deptype in ('a', 'n')
+              AND pg_catalog.pg_table_is_visible(tbl.oid)
+              AND tbl.relname = %s
+        """, [table_name])
+        return [
+            {'name': row[0], 'table': table_name, 'column': row[1]}
+            for row in cursor.fetchall()
+        ]
+
+    def get_relations(self, cursor, table_name):
+        """
+        Return a dictionary of {field_name: (field_name_other_table, other_table)}
+        representing all relationships to the given table.
+        """
+        return {row[0]: (row[2], row[1]) for row in self.get_key_columns(cursor, table_name)}
+
+    def get_key_columns(self, cursor, table_name):
+        cursor.execute("""
+            SELECT a1.attname, c2.relname, a2.attname
+            FROM pg_constraint con
+            LEFT JOIN pg_class c1 ON con.conrelid = c1.oid
+            LEFT JOIN pg_class c2 ON con.confrelid = c2.oid
+            LEFT JOIN pg_attribute a1 ON c1.oid = a1.attrelid AND a1.attnum = con.conkey[1]
+            LEFT JOIN pg_attribute a2 ON c2.oid = a2.attrelid AND a2.attnum = con.confkey[1]
+            WHERE
+                c1.relname = %s AND
+                con.contype = 'f' AND
+                c1.relnamespace = c2.relnamespace AND
+                pg_catalog.pg_table_is_visible(c1.oid)
+        """, [table_name])
+        return cursor.fetchall()
+
+    def get_constraints(self, cursor, table_name):
+        """
+        Retrieve any constraints or keys (unique, pk, fk, check, index) across
+        one or more columns. Also retrieve the definition of expression-based
+        indexes.
+        """
+        constraints = {}
+        # Loop over the key table, collecting things as constraints. The column
+        # array must return column names in the same order in which they were
+        # created.
+        cursor.execute("""
+            SELECT
+                c.conname,
+                array(
+                    SELECT attname
+                    FROM unnest(c.conkey) WITH ORDINALITY cols(colid, arridx)
+                    JOIN pg_attribute AS ca ON cols.colid = ca.attnum
+                    WHERE ca.attrelid = c.conrelid
+                    ORDER BY cols.arridx
+                ),
+                c.contype,
+                (SELECT fkc.relname || '.' || fka.attname
+                FROM pg_attribute AS fka
+                JOIN pg_class AS fkc ON fka.attrelid = fkc.oid
+                WHERE fka.attrelid = c.confrelid AND fka.attnum = c.confkey[1]),
+                cl.reloptions
+            FROM pg_constraint AS c
+            JOIN pg_class AS cl ON c.conrelid = cl.oid
+            WHERE cl.relname = %s AND pg_catalog.pg_table_is_visible(cl.oid)
+        """, [table_name])
+        for constraint, columns, kind, used_cols, options in cursor.fetchall():
+            constraints[constraint] = {
+                "columns": columns,
+                "primary_key": kind == "p",
+                "unique": kind in ["p", "u"],
+                "foreign_key": tuple(used_cols.split(".", 1)) if kind == "f" else None,
+                "check": kind == "c",
+                "index": False,
+                "definition": None,
+                "options": options,
+            }
+        # Now get indexes
+        cursor.execute("""
+            SELECT
+                indexname, array_agg(attname ORDER BY arridx), indisunique, indisprimary,
+                array_agg(ordering ORDER BY arridx), amname, exprdef, s2.attoptions
+            FROM (
+                SELECT
+                    c2.relname as indexname, idx.*, attr.attname, am.amname,
+                    CASE
+                        WHEN idx.indexprs IS NOT NULL THEN
+                            pg_get_indexdef(idx.indexrelid)
+                    END AS exprdef,
+                    CASE am.amname
+                        WHEN %s THEN
+                            CASE (option & 1)
+                                WHEN 1 THEN 'DESC' ELSE 'ASC'
+                            END
+                    END as ordering,
+                    c2.reloptions as attoptions
+                FROM (
+                    SELECT *
+                    FROM pg_index i, unnest(i.indkey, i.indoption) WITH ORDINALITY koi(key, option, arridx)
+                ) idx
+                LEFT JOIN pg_class c ON idx.indrelid = c.oid
+                LEFT JOIN pg_class c2 ON idx.indexrelid = c2.oid
+                LEFT JOIN pg_am am ON c2.relam = am.oid
+                LEFT JOIN pg_attribute attr ON attr.attrelid = c.oid AND attr.attnum = idx.key
+                WHERE c.relname = %s AND pg_catalog.pg_table_is_visible(c.oid)
+            ) s2
+            GROUP BY indexname, indisunique, indisprimary, amname, exprdef, attoptions;
+        """, [self.index_default_access_method, table_name])
+        for index, columns, unique, primary, orders, type_, definition, options in cursor.fetchall():
+            if index not in constraints:
+                basic_index = (
+                    type_ == self.index_default_access_method and
+                    # '_btree' references
+                    # django.contrib.postgres.indexes.BTreeIndex.suffix.
+                    not index.endswith('_btree') and options is None
+                )
+                constraints[index] = {
+                    "columns": columns if columns != [None] else [],
+                    "orders": orders if orders != [None] else [],
+                    "primary_key": primary,
+                    "unique": unique,
+                    "foreign_key": None,
+                    "check": False,
+                    "index": True,
+                    "type": Index.suffix if basic_index else type_,
+                    "definition": definition,
+                    "options": options,
+                }
+        return constraints

--- a/django/db/backends/postgresql_psycopg3/operations.py
+++ b/django/db/backends/postgresql_psycopg3/operations.py
@@ -1,0 +1,275 @@
+from psycopg2.extras import Inet
+
+from django.conf import settings
+from django.db.backends.base.operations import BaseDatabaseOperations
+
+
+class DatabaseOperations(BaseDatabaseOperations):
+    cast_char_field_without_max_length = 'varchar'
+    explain_prefix = 'EXPLAIN'
+    cast_data_types = {
+        'AutoField': 'integer',
+        'BigAutoField': 'bigint',
+        'SmallAutoField': 'smallint',
+    }
+
+    def unification_cast_sql(self, output_field):
+        internal_type = output_field.get_internal_type()
+        if internal_type in ("GenericIPAddressField", "IPAddressField", "TimeField", "UUIDField"):
+            # PostgreSQL will resolve a union as type 'text' if input types are
+            # 'unknown'.
+            # https://www.postgresql.org/docs/current/typeconv-union-case.html
+            # These fields cannot be implicitly cast back in the default
+            # PostgreSQL configuration so we need to explicitly cast them.
+            # We must also remove components of the type within brackets:
+            # varchar(255) -> varchar.
+            return 'CAST(%%s AS %s)' % output_field.db_type(self.connection).split('(')[0]
+        return '%s'
+
+    def date_extract_sql(self, lookup_type, field_name):
+        # https://www.postgresql.org/docs/current/functions-datetime.html#FUNCTIONS-DATETIME-EXTRACT
+        if lookup_type == 'week_day':
+            # For consistency across backends, we return Sunday=1, Saturday=7.
+            return "EXTRACT('dow' FROM %s) + 1" % field_name
+        elif lookup_type == 'iso_week_day':
+            return "EXTRACT('isodow' FROM %s)" % field_name
+        elif lookup_type == 'iso_year':
+            return "EXTRACT('isoyear' FROM %s)" % field_name
+        else:
+            return "EXTRACT('%s' FROM %s)" % (lookup_type, field_name)
+
+    def date_trunc_sql(self, lookup_type, field_name, tzname=None):
+        field_name = self._convert_field_to_tz(field_name, tzname)
+        # https://www.postgresql.org/docs/current/functions-datetime.html#FUNCTIONS-DATETIME-TRUNC
+        return "DATE_TRUNC('%s', %s)" % (lookup_type, field_name)
+
+    def _prepare_tzname_delta(self, tzname):
+        if '+' in tzname:
+            return tzname.replace('+', '-')
+        elif '-' in tzname:
+            return tzname.replace('-', '+')
+        return tzname
+
+    def _convert_field_to_tz(self, field_name, tzname):
+        if tzname and settings.USE_TZ:
+            field_name = "%s AT TIME ZONE '%s'" % (field_name, self._prepare_tzname_delta(tzname))
+        return field_name
+
+    def datetime_cast_date_sql(self, field_name, tzname):
+        field_name = self._convert_field_to_tz(field_name, tzname)
+        return '(%s)::date' % field_name
+
+    def datetime_cast_time_sql(self, field_name, tzname):
+        field_name = self._convert_field_to_tz(field_name, tzname)
+        return '(%s)::time' % field_name
+
+    def datetime_extract_sql(self, lookup_type, field_name, tzname):
+        field_name = self._convert_field_to_tz(field_name, tzname)
+        return self.date_extract_sql(lookup_type, field_name)
+
+    def datetime_trunc_sql(self, lookup_type, field_name, tzname):
+        field_name = self._convert_field_to_tz(field_name, tzname)
+        # https://www.postgresql.org/docs/current/functions-datetime.html#FUNCTIONS-DATETIME-TRUNC
+        return "DATE_TRUNC('%s', %s)" % (lookup_type, field_name)
+
+    def time_trunc_sql(self, lookup_type, field_name, tzname=None):
+        field_name = self._convert_field_to_tz(field_name, tzname)
+        return "DATE_TRUNC('%s', %s)::time" % (lookup_type, field_name)
+
+    def deferrable_sql(self):
+        return " DEFERRABLE INITIALLY DEFERRED"
+
+    def fetch_returned_insert_rows(self, cursor):
+        """
+        Given a cursor object that has just performed an INSERT...RETURNING
+        statement into a table, return the tuple of returned data.
+        """
+        return cursor.fetchall()
+
+    def lookup_cast(self, lookup_type, internal_type=None):
+        lookup = '%s'
+
+        # Cast text lookups to text to allow things like filter(x__contains=4)
+        if lookup_type in ('iexact', 'contains', 'icontains', 'startswith',
+                           'istartswith', 'endswith', 'iendswith', 'regex', 'iregex'):
+            if internal_type in ('IPAddressField', 'GenericIPAddressField'):
+                lookup = "HOST(%s)"
+            elif internal_type in ('CICharField', 'CIEmailField', 'CITextField'):
+                lookup = '%s::citext'
+            else:
+                lookup = "%s::text"
+
+        # Use UPPER(x) for case-insensitive lookups; it's faster.
+        if lookup_type in ('iexact', 'icontains', 'istartswith', 'iendswith'):
+            lookup = 'UPPER(%s)' % lookup
+
+        return lookup
+
+    def no_limit_value(self):
+        return None
+
+    def prepare_sql_script(self, sql):
+        return [sql]
+
+    def quote_name(self, name):
+        if name.startswith('"') and name.endswith('"'):
+            return name  # Quoting once is enough.
+        return '"%s"' % name
+
+    def set_time_zone_sql(self):
+        return "SET TIME ZONE %s"
+
+    def sql_flush(self, style, tables, *, reset_sequences=False, allow_cascade=False):
+        if not tables:
+            return []
+
+        # Perform a single SQL 'TRUNCATE x, y, z...;' statement. It allows us
+        # to truncate tables referenced by a foreign key in any other table.
+        sql_parts = [
+            style.SQL_KEYWORD('TRUNCATE'),
+            ', '.join(style.SQL_FIELD(self.quote_name(table)) for table in tables),
+        ]
+        if reset_sequences:
+            sql_parts.append(style.SQL_KEYWORD('RESTART IDENTITY'))
+        if allow_cascade:
+            sql_parts.append(style.SQL_KEYWORD('CASCADE'))
+        return ['%s;' % ' '.join(sql_parts)]
+
+    def sequence_reset_by_name_sql(self, style, sequences):
+        # 'ALTER SEQUENCE sequence_name RESTART WITH 1;'... style SQL statements
+        # to reset sequence indices
+        sql = []
+        for sequence_info in sequences:
+            table_name = sequence_info['table']
+            # 'id' will be the case if it's an m2m using an autogenerated
+            # intermediate table (see BaseDatabaseIntrospection.sequence_list).
+            column_name = sequence_info['column'] or 'id'
+            sql.append("%s setval(pg_get_serial_sequence('%s','%s'), 1, false);" % (
+                style.SQL_KEYWORD('SELECT'),
+                style.SQL_TABLE(self.quote_name(table_name)),
+                style.SQL_FIELD(column_name),
+            ))
+        return sql
+
+    def tablespace_sql(self, tablespace, inline=False):
+        if inline:
+            return "USING INDEX TABLESPACE %s" % self.quote_name(tablespace)
+        else:
+            return "TABLESPACE %s" % self.quote_name(tablespace)
+
+    def sequence_reset_sql(self, style, model_list):
+        from django.db import models
+        output = []
+        qn = self.quote_name
+        for model in model_list:
+            # Use `coalesce` to set the sequence for each model to the max pk value if there are records,
+            # or 1 if there are none. Set the `is_called` property (the third argument to `setval`) to true
+            # if there are records (as the max pk value is already in use), otherwise set it to false.
+            # Use pg_get_serial_sequence to get the underlying sequence name from the table name
+            # and column name (available since PostgreSQL 8)
+
+            for f in model._meta.local_fields:
+                if isinstance(f, models.AutoField):
+                    output.append(
+                        "%s setval(pg_get_serial_sequence('%s','%s'), "
+                        "coalesce(max(%s), 1), max(%s) %s null) %s %s;" % (
+                            style.SQL_KEYWORD('SELECT'),
+                            style.SQL_TABLE(qn(model._meta.db_table)),
+                            style.SQL_FIELD(f.column),
+                            style.SQL_FIELD(qn(f.column)),
+                            style.SQL_FIELD(qn(f.column)),
+                            style.SQL_KEYWORD('IS NOT'),
+                            style.SQL_KEYWORD('FROM'),
+                            style.SQL_TABLE(qn(model._meta.db_table)),
+                        )
+                    )
+                    break  # Only one AutoField is allowed per model, so don't bother continuing.
+        return output
+
+    def prep_for_iexact_query(self, x):
+        return x
+
+    def max_name_length(self):
+        """
+        Return the maximum length of an identifier.
+
+        The maximum length of an identifier is 63 by default, but can be
+        changed by recompiling PostgreSQL after editing the NAMEDATALEN
+        macro in src/include/pg_config_manual.h.
+
+        This implementation returns 63, but can be overridden by a custom
+        database backend that inherits most of its behavior from this one.
+        """
+        return 63
+
+    def distinct_sql(self, fields, params):
+        if fields:
+            params = [param for param_list in params for param in param_list]
+            return (['DISTINCT ON (%s)' % ', '.join(fields)], params)
+        else:
+            return ['DISTINCT'], []
+
+    def last_executed_query(self, cursor, sql, params):
+        # https://www.psycopg.org/docs/cursor.html#cursor.query
+        # The query attribute is a Psycopg extension to the DB API 2.0.
+        if cursor.query is not None:
+            return cursor.query.decode()
+        return None
+
+    def return_insert_columns(self, fields):
+        if not fields:
+            return '', ()
+        columns = [
+            '%s.%s' % (
+                self.quote_name(field.model._meta.db_table),
+                self.quote_name(field.column),
+            ) for field in fields
+        ]
+        return 'RETURNING %s' % ', '.join(columns), ()
+
+    def bulk_insert_sql(self, fields, placeholder_rows):
+        placeholder_rows_sql = (", ".join(row) for row in placeholder_rows)
+        values_sql = ", ".join("(%s)" % sql for sql in placeholder_rows_sql)
+        return "VALUES " + values_sql
+
+    def adapt_datefield_value(self, value):
+        return value
+
+    def adapt_datetimefield_value(self, value):
+        return value
+
+    def adapt_timefield_value(self, value):
+        return value
+
+    def adapt_decimalfield_value(self, value, max_digits=None, decimal_places=None):
+        return value
+
+    def adapt_ipaddressfield_value(self, value):
+        if value:
+            return Inet(value)
+        return None
+
+    def subtract_temporals(self, internal_type, lhs, rhs):
+        if internal_type == 'DateField':
+            lhs_sql, lhs_params = lhs
+            rhs_sql, rhs_params = rhs
+            params = (*lhs_params, *rhs_params)
+            return "(interval '1 day' * (%s - %s))" % (lhs_sql, rhs_sql), params
+        return super().subtract_temporals(internal_type, lhs, rhs)
+
+    def explain_query_prefix(self, format=None, **options):
+        prefix = super().explain_query_prefix(format)
+        extra = {}
+        if format:
+            extra['FORMAT'] = format
+        if options:
+            extra.update({
+                name.upper(): 'true' if value else 'false'
+                for name, value in options.items()
+            })
+        if extra:
+            prefix += ' (%s)' % ', '.join('%s %s' % i for i in extra.items())
+        return prefix
+
+    def ignore_conflicts_suffix_sql(self, ignore_conflicts=None):
+        return 'ON CONFLICT DO NOTHING' if ignore_conflicts else super().ignore_conflicts_suffix_sql(ignore_conflicts)

--- a/django/db/backends/postgresql_psycopg3/operations.py
+++ b/django/db/backends/postgresql_psycopg3/operations.py
@@ -118,7 +118,7 @@ class DatabaseOperations(BaseDatabaseOperations):
         return '"%s"' % name
 
     def set_time_zone_sql(self):
-        return "SET TIME ZONE %s"
+        return "select set_config('TimeZone', %s, false)"
 
     def sql_flush(self, style, tables, *, reset_sequences=False, allow_cascade=False):
         if not tables:

--- a/django/db/backends/postgresql_psycopg3/operations.py
+++ b/django/db/backends/postgresql_psycopg3/operations.py
@@ -254,12 +254,6 @@ class DatabaseOperations(BaseDatabaseOperations):
             return ipaddress.ip_network(value)
         return None
 
-    def json_placeholder_sql(self, value):
-        return '%s'
-
-    def adapt_json_value(self, value):
-        return JsonWrapper(value) if value is not None else None
-
     def subtract_temporals(self, internal_type, lhs, rhs):
         if internal_type == 'DateField':
             lhs_sql, lhs_params = lhs
@@ -284,11 +278,3 @@ class DatabaseOperations(BaseDatabaseOperations):
 
     def ignore_conflicts_suffix_sql(self, ignore_conflicts=None):
         return 'ON CONFLICT DO NOTHING' if ignore_conflicts else super().ignore_conflicts_suffix_sql(ignore_conflicts)
-
-
-class JsonWrapper:
-    """
-    A thin wrapper to mark that a string is a json and use the right oid
-    """
-    def __init__(self, obj):
-        self.wrapped = obj

--- a/django/db/backends/postgresql_psycopg3/operations.py
+++ b/django/db/backends/postgresql_psycopg3/operations.py
@@ -213,8 +213,9 @@ class DatabaseOperations(BaseDatabaseOperations):
     def last_executed_query(self, cursor, sql, params):
         # https://www.psycopg.org/docs/cursor.html#cursor.query
         # The query attribute is a Psycopg extension to the DB API 2.0.
-        if cursor.query is not None:
-            return cursor.query.decode()
+        # TODO: psycopg3
+        # if cursor.query is not None:
+        #     return cursor.query.decode()
         return None
 
     def return_insert_columns(self, fields):

--- a/django/db/backends/postgresql_psycopg3/operations.py
+++ b/django/db/backends/postgresql_psycopg3/operations.py
@@ -1,6 +1,7 @@
 # TODO: psycopg3
 # from psycopg2.extras import Inet
 
+import ipaddress
 from django.conf import settings
 from django.db.backends.base.operations import BaseDatabaseOperations
 
@@ -250,9 +251,7 @@ class DatabaseOperations(BaseDatabaseOperations):
 
     def adapt_ipaddressfield_value(self, value):
         if value:
-            # TODO: implement for psycopg3
-            # return Inet(value)
-            return value
+            return ipaddress.ip_network(value)
         return None
 
     def subtract_temporals(self, internal_type, lhs, rhs):

--- a/django/db/backends/postgresql_psycopg3/operations.py
+++ b/django/db/backends/postgresql_psycopg3/operations.py
@@ -255,7 +255,10 @@ class DatabaseOperations(BaseDatabaseOperations):
         return None
 
     def json_placeholder_sql(self, value):
-        return '%s::jsonb'
+        return '%s'
+
+    def adapt_json_value(self, value):
+        return JsonWrapper(value) if value is not None else None
 
     def subtract_temporals(self, internal_type, lhs, rhs):
         if internal_type == 'DateField':
@@ -281,3 +284,11 @@ class DatabaseOperations(BaseDatabaseOperations):
 
     def ignore_conflicts_suffix_sql(self, ignore_conflicts=None):
         return 'ON CONFLICT DO NOTHING' if ignore_conflicts else super().ignore_conflicts_suffix_sql(ignore_conflicts)
+
+
+class JsonWrapper:
+    """
+    A thin wrapper to mark that a string is a json and use the right oid
+    """
+    def __init__(self, obj):
+        self.wrapped = obj

--- a/django/db/backends/postgresql_psycopg3/operations.py
+++ b/django/db/backends/postgresql_psycopg3/operations.py
@@ -1,4 +1,5 @@
-from psycopg2.extras import Inet
+# TODO: psycopg3
+# from psycopg2.extras import Inet
 
 from django.conf import settings
 from django.db.backends.base.operations import BaseDatabaseOperations
@@ -246,7 +247,9 @@ class DatabaseOperations(BaseDatabaseOperations):
 
     def adapt_ipaddressfield_value(self, value):
         if value:
-            return Inet(value)
+            # TODO: implement for psycopg3
+            # return Inet(value)
+            return value
         return None
 
     def subtract_temporals(self, internal_type, lhs, rhs):

--- a/django/db/backends/postgresql_psycopg3/operations.py
+++ b/django/db/backends/postgresql_psycopg3/operations.py
@@ -254,6 +254,9 @@ class DatabaseOperations(BaseDatabaseOperations):
             return ipaddress.ip_network(value)
         return None
 
+    def json_placeholder_sql(self, value):
+        return '%s::jsonb'
+
     def subtract_temporals(self, internal_type, lhs, rhs):
         if internal_type == 'DateField':
             lhs_sql, lhs_params = lhs

--- a/django/db/backends/postgresql_psycopg3/schema.py
+++ b/django/db/backends/postgresql_psycopg3/schema.py
@@ -1,4 +1,4 @@
-import psycopg2
+import psycopg3.sql
 
 from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 from django.db.backends.ddl_references import IndexColumns
@@ -38,11 +38,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
     def quote_value(self, value):
         if isinstance(value, str):
             value = value.replace('%', '%%')
-        adapted = psycopg2.extensions.adapt(value)
-        if hasattr(adapted, 'encoding'):
-            adapted.encoding = 'utf8'
-        # getquoted() returns a quoted bytestring of the adapted value.
-        return adapted.getquoted().decode()
+        return psycopg3.sql.quote(value)
 
     def _field_indexes_sql(self, model, field):
         output = super()._field_indexes_sql(model, field)

--- a/django/db/backends/postgresql_psycopg3/schema.py
+++ b/django/db/backends/postgresql_psycopg3/schema.py
@@ -1,0 +1,227 @@
+import psycopg2
+
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+from django.db.backends.ddl_references import IndexColumns
+from django.db.backends.utils import strip_quotes
+
+
+class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
+
+    sql_create_sequence = "CREATE SEQUENCE %(sequence)s"
+    sql_delete_sequence = "DROP SEQUENCE IF EXISTS %(sequence)s CASCADE"
+    sql_set_sequence_max = "SELECT setval('%(sequence)s', MAX(%(column)s)) FROM %(table)s"
+    sql_set_sequence_owner = 'ALTER SEQUENCE %(sequence)s OWNED BY %(table)s.%(column)s'
+
+    sql_create_index = (
+        'CREATE INDEX %(name)s ON %(table)s%(using)s '
+        '(%(columns)s)%(include)s%(extra)s%(condition)s'
+    )
+    sql_create_index_concurrently = (
+        'CREATE INDEX CONCURRENTLY %(name)s ON %(table)s%(using)s '
+        '(%(columns)s)%(include)s%(extra)s%(condition)s'
+    )
+    sql_delete_index = "DROP INDEX IF EXISTS %(name)s"
+    sql_delete_index_concurrently = "DROP INDEX CONCURRENTLY IF EXISTS %(name)s"
+
+    # Setting the constraint to IMMEDIATE to allow changing data in the same
+    # transaction.
+    sql_create_column_inline_fk = (
+        'CONSTRAINT %(name)s REFERENCES %(to_table)s(%(to_column)s)%(deferrable)s'
+        '; SET CONSTRAINTS %(namespace)s%(name)s IMMEDIATE'
+    )
+    # Setting the constraint to IMMEDIATE runs any deferred checks to allow
+    # dropping it in the same transaction.
+    sql_delete_fk = "SET CONSTRAINTS %(name)s IMMEDIATE; ALTER TABLE %(table)s DROP CONSTRAINT %(name)s"
+
+    sql_delete_procedure = 'DROP FUNCTION %(procedure)s(%(param_types)s)'
+
+    def quote_value(self, value):
+        if isinstance(value, str):
+            value = value.replace('%', '%%')
+        adapted = psycopg2.extensions.adapt(value)
+        if hasattr(adapted, 'encoding'):
+            adapted.encoding = 'utf8'
+        # getquoted() returns a quoted bytestring of the adapted value.
+        return adapted.getquoted().decode()
+
+    def _field_indexes_sql(self, model, field):
+        output = super()._field_indexes_sql(model, field)
+        like_index_statement = self._create_like_index_sql(model, field)
+        if like_index_statement is not None:
+            output.append(like_index_statement)
+        return output
+
+    def _field_data_type(self, field):
+        if field.is_relation:
+            return field.rel_db_type(self.connection)
+        return self.connection.data_types.get(
+            field.get_internal_type(),
+            field.db_type(self.connection),
+        )
+
+    def _field_base_data_types(self, field):
+        # Yield base data types for array fields.
+        if field.base_field.get_internal_type() == 'ArrayField':
+            yield from self._field_base_data_types(field.base_field)
+        else:
+            yield self._field_data_type(field.base_field)
+
+    def _create_like_index_sql(self, model, field):
+        """
+        Return the statement to create an index with varchar operator pattern
+        when the column type is 'varchar' or 'text', otherwise return None.
+        """
+        db_type = field.db_type(connection=self.connection)
+        if db_type is not None and (field.db_index or field.unique):
+            # Fields with database column types of `varchar` and `text` need
+            # a second index that specifies their operator class, which is
+            # needed when performing correct LIKE queries outside the
+            # C locale. See #12234.
+            #
+            # The same doesn't apply to array fields such as varchar[size]
+            # and text[size], so skip them.
+            if '[' in db_type:
+                return None
+            if db_type.startswith('varchar'):
+                return self._create_index_sql(model, [field], suffix='_like', opclasses=['varchar_pattern_ops'])
+            elif db_type.startswith('text'):
+                return self._create_index_sql(model, [field], suffix='_like', opclasses=['text_pattern_ops'])
+        return None
+
+    def _alter_column_type_sql(self, model, old_field, new_field, new_type):
+        self.sql_alter_column_type = 'ALTER COLUMN %(column)s TYPE %(type)s'
+        # Cast when data type changed.
+        using_sql = ' USING %(column)s::%(type)s'
+        new_internal_type = new_field.get_internal_type()
+        old_internal_type = old_field.get_internal_type()
+        if new_internal_type == 'ArrayField' and new_internal_type == old_internal_type:
+            # Compare base data types for array fields.
+            if list(self._field_base_data_types(old_field)) != list(self._field_base_data_types(new_field)):
+                self.sql_alter_column_type += using_sql
+        elif self._field_data_type(old_field) != self._field_data_type(new_field):
+            self.sql_alter_column_type += using_sql
+        # Make ALTER TYPE with SERIAL make sense.
+        table = strip_quotes(model._meta.db_table)
+        serial_fields_map = {'bigserial': 'bigint', 'serial': 'integer', 'smallserial': 'smallint'}
+        if new_type.lower() in serial_fields_map:
+            column = strip_quotes(new_field.column)
+            sequence_name = "%s_%s_seq" % (table, column)
+            return (
+                (
+                    self.sql_alter_column_type % {
+                        "column": self.quote_name(column),
+                        "type": serial_fields_map[new_type.lower()],
+                    },
+                    [],
+                ),
+                [
+                    (
+                        self.sql_delete_sequence % {
+                            "sequence": self.quote_name(sequence_name),
+                        },
+                        [],
+                    ),
+                    (
+                        self.sql_create_sequence % {
+                            "sequence": self.quote_name(sequence_name),
+                        },
+                        [],
+                    ),
+                    (
+                        self.sql_alter_column % {
+                            "table": self.quote_name(table),
+                            "changes": self.sql_alter_column_default % {
+                                "column": self.quote_name(column),
+                                "default": "nextval('%s')" % self.quote_name(sequence_name),
+                            }
+                        },
+                        [],
+                    ),
+                    (
+                        self.sql_set_sequence_max % {
+                            "table": self.quote_name(table),
+                            "column": self.quote_name(column),
+                            "sequence": self.quote_name(sequence_name),
+                        },
+                        [],
+                    ),
+                    (
+                        self.sql_set_sequence_owner % {
+                            'table': self.quote_name(table),
+                            'column': self.quote_name(column),
+                            'sequence': self.quote_name(sequence_name),
+                        },
+                        [],
+                    ),
+                ],
+            )
+        elif old_field.db_parameters(connection=self.connection)['type'] in serial_fields_map:
+            # Drop the sequence if migrating away from AutoField.
+            column = strip_quotes(new_field.column)
+            sequence_name = '%s_%s_seq' % (table, column)
+            fragment, _ = super()._alter_column_type_sql(model, old_field, new_field, new_type)
+            return fragment, [
+                (
+                    self.sql_delete_sequence % {
+                        'sequence': self.quote_name(sequence_name),
+                    },
+                    [],
+                ),
+            ]
+        else:
+            return super()._alter_column_type_sql(model, old_field, new_field, new_type)
+
+    def _alter_field(self, model, old_field, new_field, old_type, new_type,
+                     old_db_params, new_db_params, strict=False):
+        # Drop indexes on varchar/text/citext columns that are changing to a
+        # different type.
+        if (old_field.db_index or old_field.unique) and (
+            (old_type.startswith('varchar') and not new_type.startswith('varchar')) or
+            (old_type.startswith('text') and not new_type.startswith('text')) or
+            (old_type.startswith('citext') and not new_type.startswith('citext'))
+        ):
+            index_name = self._create_index_name(model._meta.db_table, [old_field.column], suffix='_like')
+            self.execute(self._delete_index_sql(model, index_name))
+
+        super()._alter_field(
+            model, old_field, new_field, old_type, new_type, old_db_params,
+            new_db_params, strict,
+        )
+        # Added an index? Create any PostgreSQL-specific indexes.
+        if ((not (old_field.db_index or old_field.unique) and new_field.db_index) or
+                (not old_field.unique and new_field.unique)):
+            like_index_statement = self._create_like_index_sql(model, new_field)
+            if like_index_statement is not None:
+                self.execute(like_index_statement)
+
+        # Removed an index? Drop any PostgreSQL-specific indexes.
+        if old_field.unique and not (new_field.db_index or new_field.unique):
+            index_to_remove = self._create_index_name(model._meta.db_table, [old_field.column], suffix='_like')
+            self.execute(self._delete_index_sql(model, index_to_remove))
+
+    def _index_columns(self, table, columns, col_suffixes, opclasses):
+        if opclasses:
+            return IndexColumns(table, columns, self.quote_name, col_suffixes=col_suffixes, opclasses=opclasses)
+        return super()._index_columns(table, columns, col_suffixes, opclasses)
+
+    def add_index(self, model, index, concurrently=False):
+        self.execute(index.create_sql(model, self, concurrently=concurrently), params=None)
+
+    def remove_index(self, model, index, concurrently=False):
+        self.execute(index.remove_sql(model, self, concurrently=concurrently))
+
+    def _delete_index_sql(self, model, name, sql=None, concurrently=False):
+        sql = self.sql_delete_index_concurrently if concurrently else self.sql_delete_index
+        return super()._delete_index_sql(model, name, sql)
+
+    def _create_index_sql(
+        self, model, fields, *, name=None, suffix='', using='',
+        db_tablespace=None, col_suffixes=(), sql=None, opclasses=(),
+        condition=None, concurrently=False, include=None,
+    ):
+        sql = self.sql_create_index if not concurrently else self.sql_create_index_concurrently
+        return super()._create_index_sql(
+            model, fields, name=name, suffix=suffix, using=using, db_tablespace=db_tablespace,
+            col_suffixes=col_suffixes, sql=sql, opclasses=opclasses, condition=condition,
+            include=include,
+        )

--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -147,6 +147,26 @@ class Combinable:
         )
 
 
+class PostgreSQLNumericMixin:
+    # types accepted by the server for server-side binding
+    _pg_types = {
+        Combinable.BITAND: 'Int8',
+        Combinable.BITOR: 'Int8',
+        Combinable.BITLEFTSHIFT: 'Int4',
+        Combinable.BITRIGHTSHIFT: 'Int4',
+        Combinable.BITXOR: 'Int8',
+    }
+
+    def as_postgresql(self, compiler, connection):
+        res = self.as_sql(compiler, connection)
+        if connection.features.is_psycopg3:
+            if self.connector in self._pg_types:
+                import psycopg3.types.numeric
+                Type = getattr(psycopg3.types.numeric, self._pg_types[self.connector])
+                res[1][0] = Type(res[1][0])
+        return res
+
+
 @deconstructible
 class BaseExpression:
     """Base class for all query expressions."""
@@ -439,7 +459,7 @@ def _resolve_combined_type(connector, lhs_type, rhs_type):
             return combined_type
 
 
-class CombinedExpression(SQLiteNumericMixin, Expression):
+class CombinedExpression(PostgreSQLNumericMixin, SQLiteNumericMixin, Expression):
 
     def __init__(self, lhs, connector, rhs, output_field=None):
         super().__init__(output_field=output_field)

--- a/django/db/models/fields/json.py
+++ b/django/db/models/fields/json.py
@@ -83,20 +83,10 @@ class JSONField(CheckFieldDefaultMixin, Field):
     def get_internal_type(self):
         return 'JSONField'
 
-    def get_placeholder(self, value, compiler, connection):
-        return connection.ops.json_placeholder_sql(value)
-
     def get_prep_value(self, value):
         if value is None:
             return value
         return json.dumps(value, cls=self.encoder)
-
-    def get_db_prep_value(self, value, connection, prepared=False):
-        if not prepared:
-            value = self.get_prep_value(value)
-            return connection.ops.adapt_json_value(value)
-        else:
-            return value
 
     def get_transform(self, name):
         transform = super().get_transform(name)
@@ -140,19 +130,7 @@ def compile_json_path(key_transforms, include_root=True):
     return ''.join(path)
 
 
-class PostgresCastRhsJson:
-    def process_rhs(self, compiler, connection):
-        rhs, rhs_params = super().process_rhs(compiler, connection)
-        if connection.vendor == 'postgresql':
-            if rhs == "%s" and rhs_params == [None]:
-                rhs = "'null'"
-                rhs_params = []
-            else:
-                rhs = rhs + "::jsonb"
-        return rhs, rhs_params
-
-
-class DataContains(PostgresCastRhsJson, PostgresOperatorLookup):
+class DataContains(PostgresOperatorLookup):
     lookup_name = 'contains'
     postgres_operator = '@>'
 
@@ -167,7 +145,7 @@ class DataContains(PostgresCastRhsJson, PostgresOperatorLookup):
         return 'JSON_CONTAINS(%s, %s)' % (lhs, rhs), params
 
 
-class ContainedBy(PostgresCastRhsJson, PostgresOperatorLookup):
+class ContainedBy(PostgresOperatorLookup):
     lookup_name = 'contained_by'
     postgres_operator = '<@'
 
@@ -255,7 +233,7 @@ class HasAnyKeys(HasKeys):
     logical_operator = ' OR '
 
 
-class JSONExact(PostgresCastRhsJson, lookups.Exact):
+class JSONExact(lookups.Exact):
     can_use_none_as_rhs = True
 
     def process_lhs(self, compiler, connection):
@@ -275,8 +253,6 @@ class JSONExact(PostgresCastRhsJson, lookups.Exact):
         if connection.vendor == 'mysql':
             func = ["JSON_EXTRACT(%s, '$')"] * len(rhs_params)
             rhs = rhs % tuple(func)
-        # elif connection.vendor == 'postgresql':
-        #     rhs = rhs + "::jsonb"
         return rhs, rhs_params
 
 
@@ -419,8 +395,6 @@ class KeyTransformIn(lookups.In):
                 sql = "JSON_EXTRACT(%s, '$')"
         if connection.vendor == 'mysql' and connection.mysql_is_mariadb:
             sql = 'JSON_UNQUOTE(%s)' % sql
-        elif connection.vendor == 'postgresql':
-            sql = '%s::jsonb'
         return sql, params
 
 
@@ -509,19 +483,19 @@ class KeyTransformNumericLookupMixin:
         return rhs, rhs_params
 
 
-class KeyTransformLt(PostgresCastRhsJson, KeyTransformNumericLookupMixin, lookups.LessThan):
+class KeyTransformLt(KeyTransformNumericLookupMixin, lookups.LessThan):
     pass
 
 
-class KeyTransformLte(PostgresCastRhsJson, KeyTransformNumericLookupMixin, lookups.LessThanOrEqual):
+class KeyTransformLte(KeyTransformNumericLookupMixin, lookups.LessThanOrEqual):
     pass
 
 
-class KeyTransformGt(PostgresCastRhsJson, KeyTransformNumericLookupMixin, lookups.GreaterThan):
+class KeyTransformGt(KeyTransformNumericLookupMixin, lookups.GreaterThan):
     pass
 
 
-class KeyTransformGte(PostgresCastRhsJson, KeyTransformNumericLookupMixin, lookups.GreaterThanOrEqual):
+class KeyTransformGte(KeyTransformNumericLookupMixin, lookups.GreaterThanOrEqual):
     pass
 
 

--- a/django/db/models/fields/json.py
+++ b/django/db/models/fields/json.py
@@ -83,6 +83,9 @@ class JSONField(CheckFieldDefaultMixin, Field):
     def get_internal_type(self):
         return 'JSONField'
 
+    def get_placeholder(self, value, compiler, connection):
+        return connection.ops.json_placeholder_sql(value)
+
     def get_prep_value(self, value):
         if value is None:
             return value

--- a/django/db/models/functions/text.py
+++ b/django/db/models/functions/text.py
@@ -140,6 +140,13 @@ class Left(Func):
     def as_sqlite(self, compiler, connection, **extra_context):
         return self.get_substr().as_sqlite(compiler, connection, **extra_context)
 
+    def as_postgresql(self, compiler, connection, **extra_context):
+        rv = self.as_sql(compiler, connection, **extra_context)
+        if connection.features.is_psycopg3:
+            from psycopg3.types.numeric import Int4
+            rv[1][0] = Int4(rv[1][0])
+        return rv
+
 
 class Length(Transform):
     """Return the number of characters in the expression."""

--- a/django/db/models/functions/text.py
+++ b/django/db/models/functions/text.py
@@ -312,6 +312,11 @@ class Substr(Func):
     def as_oracle(self, compiler, connection, **extra_context):
         return super().as_sql(compiler, connection, function='SUBSTR', **extra_context)
 
+    def as_postgresql(self, compiler, connection, **extra_context):
+        # currently psycopg3 passes the oid of numeric and postgres cannot find a cast
+        res = super().as_sql(compiler, connection, function='SUBSTR', **extra_context)
+        return (res[0].replace("%s", "%s::integer"), res[1])
+
 
 class Trim(Transform):
     function = 'TRIM'

--- a/django/db/models/functions/text.py
+++ b/django/db/models/functions/text.py
@@ -115,6 +115,14 @@ class Concat(Func):
             return ConcatPair(*expressions)
         return ConcatPair(expressions[0], self._paired(expressions[1:]))
 
+    def as_postgresql(self, compiler, connection, **extra_context):
+        sql, params = super().as_sql(compiler, connection, **extra_context)
+        # We have to explicitly cast CONCAT arguments to text in psycopg3,
+        # because in postgres they are defined as 'VARIADIC any'
+        if connection.features.is_psycopg3:
+            sql = sql.replace('%s', '%s::text')
+        return sql, params
+
 
 class Left(Func):
     function = 'LEFT'

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -6,7 +6,7 @@ from itertools import chain
 from django.core.exceptions import EmptyResultSet, FieldError
 from django.db import DatabaseError, NotSupportedError
 from django.db.models.constants import LOOKUP_SEP
-from django.db.models.expressions import F, OrderBy, RawSQL, Ref, Value
+from django.db.models.expressions import F, OrderBy, RawSQL, Ref, Subquery, Value
 from django.db.models.functions import Cast, Random
 from django.db.models.query_utils import Q, select_related_descend
 from django.db.models.sql.constants import (
@@ -525,7 +525,8 @@ class SQLCompiler:
 
                 out_cols = []
                 col_idx = 1
-                for _, (s_sql, s_params), alias in self.select + extra_select:
+                subquery_to_idx = {}  # base1 output column of the expressions
+                for s_expr, (s_sql, s_params), alias in self.select + extra_select:
                     if alias:
                         s_sql = '%s AS %s' % (s_sql, self.connection.ops.quote_name(alias))
                     elif with_col_aliases:
@@ -533,6 +534,8 @@ class SQLCompiler:
                         col_idx += 1
                     params.extend(s_params)
                     out_cols.append(s_sql)
+                    if isinstance(s_expr, Subquery):
+                        subquery_to_idx[s_expr] = len(out_cols)
 
                 result += [', '.join(out_cols), 'FROM', *from_]
                 params.extend(f_params)
@@ -601,7 +604,14 @@ class SQLCompiler:
 
             if order_by:
                 ordering = []
-                for _, (o_sql, o_params, _) in order_by:
+                for o_expr, (o_sql, o_params, _) in order_by:
+                    if o_expr.expression in subquery_to_idx and o_sql.startswith("("):
+                        # Replace ORDER BY expressions with the position of the column index
+                        # If the query contains parameters, binding server-side will not consider
+                        # them equivalent, and DISTINCT+ORDER BY will fail.
+                        # TODO psycopg3: maybe add feature "support order column alias"?
+                        o_sql = str(subquery_to_idx[o_expr.expression]) + o_sql.rsplit(")", 1)[-1]
+                        o_params = []
                     ordering.append(o_sql)
                     params.extend(o_params)
                 result.append('ORDER BY %s' % ', '.join(ordering))

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -6,7 +6,7 @@ from itertools import chain
 from django.core.exceptions import EmptyResultSet, FieldError
 from django.db import DatabaseError, NotSupportedError
 from django.db.models.constants import LOOKUP_SEP
-from django.db.models.expressions import F, OrderBy, RawSQL, Ref, Subquery, Value
+from django.db.models.expressions import F, OrderBy, RawSQL, Ref, Value
 from django.db.models.functions import Cast, Random
 from django.db.models.query_utils import Q, select_related_descend
 from django.db.models.sql.constants import (
@@ -525,8 +525,9 @@ class SQLCompiler:
 
                 out_cols = []
                 col_idx = 1
-                subquery_to_idx = {}  # base1 output column of the expressions
-                for s_expr, (s_sql, s_params), alias in self.select + extra_select:
+                cols_and_params = []
+                for _, (s_sql, s_params), alias in self.select + extra_select:
+                    cols_and_params.append((s_sql, s_params))
                     if alias:
                         s_sql = '%s AS %s' % (s_sql, self.connection.ops.quote_name(alias))
                     elif with_col_aliases:
@@ -534,8 +535,6 @@ class SQLCompiler:
                         col_idx += 1
                     params.extend(s_params)
                     out_cols.append(s_sql)
-                    if isinstance(s_expr, Subquery):
-                        subquery_to_idx[s_expr] = len(out_cols)
 
                 result += [', '.join(out_cols), 'FROM', *from_]
                 params.extend(f_params)
@@ -583,6 +582,14 @@ class SQLCompiler:
 
                 grouping = []
                 for g_sql, g_params in group_by:
+                    if g_params:
+                        try:
+                            idx = cols_and_params.index((g_sql, g_params))
+                        except ValueError:
+                            pass
+                        else:
+                            g_sql = str(idx + 1)
+                            g_params = []
                     grouping.append(g_sql)
                     params.extend(g_params)
                 if grouping:
@@ -605,13 +612,20 @@ class SQLCompiler:
             if order_by:
                 ordering = []
                 for o_expr, (o_sql, o_params, _) in order_by:
-                    if o_expr.expression in subquery_to_idx and o_sql.startswith("("):
-                        # Replace ORDER BY expressions with the position of the column index
-                        # If the query contains parameters, binding server-side will not consider
-                        # them equivalent, and DISTINCT+ORDER BY will fail.
-                        # TODO psycopg3: maybe add feature "support order column alias"?
-                        o_sql = str(subquery_to_idx[o_expr.expression]) + o_sql.rsplit(")", 1)[-1]
-                        o_params = []
+                    # Replace ORDER BY expressions with the position of the column index
+                    # If the query contains parameters, binding server-side will not consider
+                    # them equivalent, and DISTINCT+ORDER BY will fail.
+                    # TODO psycopg3: maybe add feature "support order column alias"?
+                    if o_params and o_sql.startswith('('):
+                        o_sql_parts = o_sql.rsplit(')', 1)
+                        o_sql_parts[0] += ')'
+                        try:
+                            idx = cols_and_params.index((o_sql_parts[0], o_params))
+                        except ValueError:
+                            pass
+                        else:
+                            o_sql = str(idx + 1) + o_sql_parts[1]
+                            o_params = []
                     ordering.append(o_sql)
                     params.extend(o_params)
                 result.append('ORDER BY %s' % ', '.join(ordering))

--- a/tests/db_utils/tests.py
+++ b/tests/db_utils/tests.py
@@ -49,8 +49,12 @@ class DatabaseErrorWrapperTests(TestCase):
                 cursor.execute('DROP TABLE "X"')
         self.assertNotEqual(type(cm.exception), type(cm.exception.__cause__))
         self.assertIsNotNone(cm.exception.__cause__)
-        self.assertIsNotNone(cm.exception.__cause__.pgcode)
-        self.assertIsNotNone(cm.exception.__cause__.pgerror)
+        if connection.features.is_psycopg2:
+            self.assertIsNotNone(cm.exception.__cause__.pgcode)
+            self.assertIsNotNone(cm.exception.__cause__.pgerror)
+        if connection.features.is_psycopg3:
+            self.assertIsNotNone(cm.exception.__cause__.diag.sqlstate)
+            self.assertIsNotNone(cm.exception.__cause__.diag.message_primary)
 
 
 class LoadBackendTests(SimpleTestCase):

--- a/tests/fixtures/tests.py
+++ b/tests/fixtures/tests.py
@@ -13,7 +13,7 @@ from django.core.files.temp import NamedTemporaryFile
 from django.core.management import CommandError
 from django.core.management.commands.dumpdata import ProxyModelWarning
 from django.core.serializers.base import ProgressBar
-from django.db import IntegrityError, connection
+from django.db import DataError, IntegrityError, connection
 from django.test import TestCase, TransactionTestCase, skipUnlessDBFeature
 
 from .models import (
@@ -608,13 +608,12 @@ class FixtureLoadingTests(DumpDataAssertMixin, TestCase):
         with self.assertRaisesMessage(IntegrityError, msg):
             management.call_command('loaddata', 'invalid.json', verbosity=0)
 
-    @unittest.skipUnless(connection.vendor == 'postgresql', 'psycopg2 prohibits null characters in data.')
+    @unittest.skipUnless(connection.vendor == 'postgresql', 'PostgreSQL prohibits null characters in data.')
     def test_loaddata_null_characters_on_postgresql(self):
-        msg = (
-            'Could not load fixtures.Article(pk=2): '
-            'A string literal cannot contain NUL (0x00) characters.'
+        pattern = (
+            r'Could not load fixtures\.Article\(pk=2\): .*\(0x00\)'
         )
-        with self.assertRaisesMessage(ValueError, msg):
+        with self.assertRaisesRegex((ValueError, DataError), pattern):
             management.call_command('loaddata', 'null_character_in_field_value.json')
 
     def test_loaddata_app_option(self):


### PR DESCRIPTION
I thoroughly checked approach with sql replacement in `as_postgresql` method for django `Func` objects and discovered serious problem. This approach will not work in case of using nested functions. 

Example can be found in `db_functions.text.test_substr.SubstrTests.test_expressions`:

```
Substr(Upper('name'), StrIndex('name', V('h')), 5)
```
Will produce following SQL:
```sql
SUBSTR(UPPER("db_functions_author"."name"), STRPOS("db_functions_author"."name", %s), %s), params: ('h', 5)
```
And code will replace all `%s` with `%s::integer`(see `Substr` class), which will lead us to typing error. 

So I've decided to focus on providing types for psycopg3, rather than modifying sql. Current implementation is a bit hacky and certainly questionable, but I hope the idea behind it is generally right.

To fix `Concat` function in nested function case using this approach, we need somehow force psycopg3 use `text` type instead of `unknown` (with the wrapper like `Int4`, I guess).

P.S `FAILED (failures=32, errors=68, skipped=399, expected failures=8)`, -35 errors!